### PR TITLE
Refactor internal data structures

### DIFF
--- a/TRX/TRX.py
+++ b/TRX/TRX.py
@@ -19,6 +19,7 @@ UIM_INFORM = 'Inform'
 UIM_DEBUG = 'Debug'
 
 UIMessage = namedtuple('UIMessage', 'message, messageType')
+Property = namedtuple('EProperty', 'displayname, matchingrule, value')
 
 
 class MaltegoEntity(object):
@@ -74,10 +75,7 @@ class MaltegoEntity(object):
         how entities will be matched and could be 'strict' (default) or 'loose'.
         See pages 30 & 50 in TRX documentation.
         """
-        self.additionalFields[fieldName] = {}
-        self.additionalFields[fieldName]['displayName'] = displayName
-        self.additionalFields[fieldName]['matchingRule'] = matchingRule
-        self.additionalFields[fieldName]['value'] = value
+        self.additionalFields[fieldName] = Property(displayName, matchingRule, value)
 
     def setIconURL(self, iU=None):
         """Define a URL pointing to a PNG or JPG for the icon.

--- a/TRX/TRX.py
+++ b/TRX/TRX.py
@@ -35,8 +35,8 @@ class MaltegoEntity(object):
         else:
             self.value = ""
         self.additionalFields = {}
+        self.displayInformation = {}
         self.weight = 100
-        self.displayInformation = []
         self.iconURL = ""
 
     def setType(self, eT=None):
@@ -64,7 +64,7 @@ class MaltegoEntity(object):
         TRX documentation.
         """
         if (di is not None):
-            self.displayInformation.append([dl, di])
+            self.displayInformation[dl] = di
 
     def addProperty(self, fieldName=None, displayName=None, matchingRule=False, value=None):
         """Add a property to the entity.
@@ -128,8 +128,8 @@ class MaltegoEntity(object):
         r += "<Weight>" + str(self.weight) + "</Weight>"
         if (len(self.displayInformation) > 0):
             r += "<DisplayInformation>"
-            for i in range(len(self.displayInformation)):
-                r += '<Label Name=\"' + self.displayInformation[i][0] + '\" Type=\"text/html\"><![CDATA[' + str(self.displayInformation[i][1]) + ']]></Label>'
+            for label in self.displayInformation:
+                r += '<Label Name=\"' + label + '\" Type=\"text/html\"><![CDATA[' + str(self.displayInformation[label]) + ']]></Label>'
             r += '</DisplayInformation>'
         if (len(self.additionalFields) > 0):
             r += "<AdditionalFields>"

--- a/TRX/TRX.py
+++ b/TRX/TRX.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from xml.dom import minidom
 
 BOOKMARK_COLOR_NONE = "-1"
@@ -16,6 +17,8 @@ UIM_FATAL = 'FatalError'
 UIM_PARTIAL = 'PartialError'
 UIM_INFORM = 'Inform'
 UIM_DEBUG = 'Debug'
+
+UIMessage = namedtuple('UIMessage', 'message, messageType')
 
 
 class MaltegoEntity(object):
@@ -165,12 +168,12 @@ class MaltegoTransform(object):
         self.entities.append(me)
         return me
 
-    def addUIMessage(self, message, messageType=UIM_INFORM):
+    def addUIMessage(self, msg, msgType=UIM_INFORM):
         """Shows a message 'msg' in the Maltego GUI.
 
-        Use UIM_* constants.
+        Use UIM_* constants for message type.
         """
-        self.UIMessages.append([messageType, message])
+        self.UIMessages.append(UIMessage(messageType=msgType, message=msg))
 
     def addException(self, exceptionString):
         """Throws a transform exception."""
@@ -202,9 +205,8 @@ class MaltegoTransform(object):
         r += "</Entities>"
 
         r += "<UIMessages>"
-        for i in range(len(self.UIMessages)):
-            r += "<UIMessage MessageType=\"" + \
-                self.UIMessages[i][0] + "\">" + self.UIMessages[i][1] + "</UIMessage>"
+        for msg in self.UIMessages:
+            r += "<UIMessage MessageType=\"" + msg.messageType + "\">" + msg.message + "</UIMessage>"
         r += "</UIMessages>"
 
         r += "</MaltegoTransformResponseMessage>"

--- a/tests/TRX_tests.py
+++ b/tests/TRX_tests.py
@@ -51,14 +51,17 @@ def test_entity_add_property():
     entity = TRX.MaltegoEntity("IPv4Address", "10.0.0.1")
     entity.addProperty("ipaddress.internal", value="True")
     assert len(entity.additionalFields) == 1
+    assert isinstance(entity.additionalFields, dict)
     assert entity.additionalFields.keys() == ["ipaddress.internal"]
-    assert entity.additionalFields["ipaddress.internal"]["value"] == "True"
+    assert isinstance(entity.additionalFields['ipaddress.internal'], TRX.Property)
+    assert entity.additionalFields["ipaddress.internal"].value == "True"
 
 
 def test_entity_displayinfo():
     entity = TRX.MaltegoEntity()
     entity.addDisplayInformation("TestValue", "TestLabel")
     assert len(entity.displayInformation) == 1
+    assert isinstance(entity.displayInformation, dict)
     assert entity.displayInformation.keys() == ["TestLabel"]
     assert entity.displayInformation['TestLabel'] == "TestValue"
 
@@ -85,6 +88,7 @@ def test_transform_add_ui_msg():
     xform = TRX.MaltegoTransform()
     xform.addUIMessage("Test Message", TRX.UIM_DEBUG)
     assert len(xform.UIMessages) == 1
+    assert isinstance(xform.UIMessages[0], TRX.UIMessage)
     assert xform.UIMessages[0].messageType == TRX.UIM_DEBUG
     assert xform.UIMessages[0].message == "Test Message"
 

--- a/tests/TRX_tests.py
+++ b/tests/TRX_tests.py
@@ -55,6 +55,14 @@ def test_entity_add_property():
     assert entity.additionalFields["ipaddress.internal"]["value"] == "True"
 
 
+def test_entity_displayinfo():
+    entity = TRX.MaltegoEntity()
+    entity.addDisplayInformation("TestValue", "TestLabel")
+    assert len(entity.displayInformation) == 1
+    assert entity.displayInformation.keys() == ["TestLabel"]
+    assert entity.displayInformation['TestLabel'] == "TestValue"
+
+
 def test_transform_creation():
     xform = TRX.MaltegoTransform()
     assert isinstance(xform, TRX.MaltegoTransform)

--- a/tests/TRX_tests.py
+++ b/tests/TRX_tests.py
@@ -77,8 +77,8 @@ def test_transform_add_ui_msg():
     xform = TRX.MaltegoTransform()
     xform.addUIMessage("Test Message", TRX.UIM_DEBUG)
     assert len(xform.UIMessages) == 1
-    assert xform.UIMessages[0][0] == TRX.UIM_DEBUG
-    assert xform.UIMessages[0][1] == "Test Message"
+    assert xform.UIMessages[0].messageType == TRX.UIM_DEBUG
+    assert xform.UIMessages[0].message == "Test Message"
 
 
 def test_transform_throw_exception():


### PR DESCRIPTION
This makes working with these data structures far more readable. See MaltegoEntity.returnEntity() and MaltegoTransform.returnOutput() as examples of this.
